### PR TITLE
[added] silent option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,9 +29,24 @@ var warn = (passed, msg) => {
     console.warn(msg);
 };
 
+var silent = () => {};
+
 module.exports = (options) => {
   var _createElement = React.createElement;
-  var log = options && options.throw ? error : warn;
+  var log = warn;
+  if (options) {
+    switch (options.level) {
+      case 'error':
+        log = error;
+        break;
+      case 'silent':
+        log = silent;
+        break;
+      case 'warn':
+      default:
+        log = warn;
+    }
+  }
   React.createElement = function (type, _props, ...children) {
     if (typeof type === 'string') {
       var props = _props || {};


### PR DESCRIPTION
In isomorphic apps, react-a11y needs to run on server and client or there is a render checksum error and the client has to re-render. This silent option can be enabled on the server so that the console isn't spammed when doing a server-side render.

`warn` is still the default