### PR TITLE
Move babel-runtime to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "Angus Croll"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "babel-runtime": "^5.1.11",
+  },
   "devDependencies": {
     "babel": "^5.2.17",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
-    "babel-runtime": "^5.1.11",
     "jsx-loader": "^0.12.2",
     "jsxhint": "^0.8.1",
     "karma": "^0.12.28",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "babel-runtime": "^5.1.11",
+    "babel-runtime": "^5.1.11"
   },
   "devDependencies": {
     "babel": "^5.2.17",


### PR DESCRIPTION
Fixes #72 

I'm just tired of email notifications on this, so I used github's editor to just fix it.