### PR TITLE
Now accepting empty `alt` attribute

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -353,7 +353,7 @@ describe('labels', () => {
 
   it('warns if an image without alt is the only content', () => {
     expectWarning(assertions.render.NO_LABEL.msg, () => {
-      <button><img src="#" alt=""/></button>;
+      <button><img src="#"/></button>;
     });
   });
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -53,7 +53,7 @@ var hasLabel = (node) => {
   images = Array.prototype.slice.call(images);
 
   var hasAltText = (images.filter((image) => {
-    return image.alt.length > 0;
+    return hasAlt(image);
   }).length) > 0;
 
   return hasTextContent || hasAltText;
@@ -89,7 +89,7 @@ var hasChildTextNode = (props, children, failureCB) => {
       return;
     else if (typeof child === 'string' || typeof child === 'number')
       hasText = true;
-    else if (child.type === 'img' && child.props.alt)
+    else if (child.type === 'img' && hasAlt(child.props))
       hasText = true;
     else if (child.props && child.props.children)
       hasText = hasChildTextNode(child.props, child.props.children, failureCB);
@@ -242,7 +242,7 @@ exports.render = {
       var failed = !(
         props['aria-label'] ||
         props['aria-labelledby'] ||
-        (tagName === 'img' && props.alt) ||
+        (tagName === 'img' && hasAlt(props)) ||
         hasChildTextNode(props, children, failureCB)
       );
 


### PR DESCRIPTION
Used the already-present `hasAlt` for consistency. The previous checks failed to consider `alt=""` as valid under some circumstances.
