### PR TITLE
[fixed] Label checks should not apply to elements with role of "separator" (fixes #91)

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -290,6 +290,12 @@ describe('labels', () => {
     });
   });
 
+  it('does not warn when `role="separator"`', () => {
+    doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+      <div role="separator"/>;
+    });
+  });
+
   it('does not warn when `aria-hidden="true"`', () => {
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
       <button aria-hidden="true"/>;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -21,7 +21,7 @@ var INTERACTIVE = {
   }
 };
 
-const presentationRoles = new Set(['presentation', 'none']);
+const presentationRoles = new Set(['presentation', 'none', 'separator']);
 
 var isHiddenFromAT = (props) => {
   return props['aria-hidden'] == 'true';


### PR DESCRIPTION
See #91.
