### PR TITLE
[fixed] should not warn if child elements without text content have aria-label or aria-labelledby (fixes #105)

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -563,6 +563,62 @@ describe('labels', () => {
       <a>{1111}</a>;
     });
   });
+
+  it('does not warn when a child component without text content has an aria-label', () => {
+    var Foo = React.createClass({
+      render: function() {
+        return (
+          <span aria-label="test label"/>
+        );
+      }
+    });
+
+    doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+      React.render(<div role="dialog"><Foo/></div>, fixture);
+    });
+  });
+
+  it('does not warn when a child component without text content has an aria-labelledby', () => {
+    var Foo = React.createClass({
+      render: function() {
+        return (
+          <span aria-labelledby="testid"/>
+        );
+      }
+    });
+
+    doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+      React.render(<div role="dialog"><Foo/></div>, fixture);
+    });
+  });
+
+  it('warns when a child component without text content has an empty aria-label', () => {
+    var Foo = React.createClass({
+      render: function() {
+        return (
+          <span aria-label=""/>
+        );
+      }
+    });
+
+    expectWarning(assertions.render.NO_LABEL.msg, () => {
+      React.render(<div role="dialog"><Foo/></div>, fixture);
+    });
+  });
+
+  it('warns when a child component without text content has an empty aria-labelledby', () => {
+    var Foo = React.createClass({
+      render: function() {
+        return (
+          <span aria-labelledby=""/>
+        );
+      }
+    });
+
+    expectWarning(assertions.render.NO_LABEL.msg, () => {
+      React.render(<div role="dialog"><Foo/></div>, fixture);
+    });
+  });
 });
 
 describe('includeSrcNode is "asString"', () => {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -56,7 +56,10 @@ var hasLabel = (node) => {
     return image.alt.length > 0;
   }).length) > 0;
 
-  return hasTextContent || hasAltText;
+  var ariaLabel = node.getAttribute('aria-label') || node.getAttribute('aria-labelledby') || '';
+  var hasAriaLabel = ariaLabel.trim().length > 0;
+
+  return hasTextContent || hasAltText || hasAriaLabel;
 };
 
 var assertLabel = function(node, context, failureCB) {


### PR DESCRIPTION
This fixes issue [#105](https://github.com/rackt/react-a11y/issues/105)
