### PR TITLE
Update to use ReactDOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ It's also possible exclude certain tests:
 ```
 a11y(React, { exclude: ['REDUNDANT_ALT'] });
 ```
+
+ReactDOM
+--------
+
+You can pass `ReactDOM` to `a11y` for `React 0.14` compatibility.
+
+```
+a11y(React, { ReactDOM: ReactDOM });
+```

--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 var assert = require('assert');
 var a11y = require('../index');
 var assertions = require('../assertions');
@@ -30,7 +31,7 @@ describe('props', () => {
   var createElement = React.createElement;
 
   before(() => {
-    a11y(React);
+    a11y(React, { ReactDOM });
   });
 
   after(() => {
@@ -154,7 +155,7 @@ describe('tags', () => {
   var createElement = React.createElement;
 
   before(() => {
-    a11y(React);
+    a11y(React, { ReactDOM });
   });
 
   after(() => {
@@ -235,7 +236,7 @@ describe('labels', () => {
   var fixture;
 
   before(() => {
-    a11y(React);
+    a11y(React, { ReactDOM });
   });
 
   after(() => {
@@ -399,7 +400,7 @@ describe('labels', () => {
     });
 
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><span><Foo/></span></div>, fixture);
+      ReactDOM.render(<div role="button"><span><Foo/></span></div>, fixture);
     });
   });
 
@@ -413,7 +414,7 @@ describe('labels', () => {
     });
 
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><Foo/></div>, fixture);
+      ReactDOM.render(<div role="button"><Foo/></div>, fixture);
     });
   });
 
@@ -427,7 +428,7 @@ describe('labels', () => {
     });
 
     expectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><Foo/></div>, fixture);
+      ReactDOM.render(<div role="button"><Foo/></div>, fixture);
     });
   });
 
@@ -443,7 +444,7 @@ describe('labels', () => {
     });
 
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><span><Foo/></span></div>, fixture);
+      ReactDOM.render(<div role="button"><span><Foo/></span></div>, fixture);
     });
   });
 
@@ -459,7 +460,7 @@ describe('labels', () => {
     });
 
     expectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><span><Foo/></span></div>, fixture);
+      ReactDOM.render(<div role="button"><span><Foo/></span></div>, fixture);
     });
   });
 
@@ -475,7 +476,7 @@ describe('labels', () => {
     });
 
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><span><Foo/></span></div>, fixture);
+      ReactDOM.render(<div role="button"><span><Foo/></span></div>, fixture);
     });
   });
 
@@ -489,7 +490,7 @@ describe('labels', () => {
     });
 
     expectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><Bar/></div>, fixture);
+      ReactDOM.render(<div role="button"><Bar/></div>, fixture);
     });
   });
 
@@ -513,7 +514,7 @@ describe('labels', () => {
     });
 
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><Bar/><Foo/></div>, fixture);
+      ReactDOM.render(<div role="button"><Bar/><Foo/></div>, fixture);
     });
   });
 
@@ -535,7 +536,7 @@ describe('labels', () => {
     });
 
     expectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><Bar/><div/><Foo/></div>, fixture);
+      ReactDOM.render(<div role="button"><Bar/><div/><Foo/></div>, fixture);
     });
   });
 
@@ -554,7 +555,7 @@ describe('labels', () => {
     });
 
     expectWarning(assertions.render.NO_LABEL.msg, () => {
-      React.render(<div role="button"><Bar/></div>, fixture);
+      ReactDOM.render(<div role="button"><Bar/></div>, fixture);
     });
   });
 
@@ -597,7 +598,7 @@ describe('includeSrcNode is "asString"', () => {
       }
     });
 
-    var msgs = captureWarnings(() => {React.render(<Bar/>, fixture);});
+    var msgs = captureWarnings(() => {ReactDOM.render(<Bar/>, fixture);});
     var regex = /^Source Node: <(\w+) .+>.*<\/\1>/;
     var matches = msgs[assertions.render.NO_LABEL.msg].match(regex);
     assert.equal(matches[1], "div");

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1,9 +1,11 @@
 var after = require('./after');
 
 var React;
+var ReactDOM;
 
-exports.setReact = function(R) {
-  React = R;
+exports.setReact = function(_React, _ReactDOM) {
+  React = _React;
+  ReactDOM = _ReactDOM || React;
 };
 
 var INTERACTIVE = {
@@ -99,7 +101,7 @@ var hasChildTextNode = (props, children, failureCB) => {
       // To account for this, check each Component's HTML after it's
       // been mounted.
       after(child.type.prototype, 'componentDidMount', function() {
-        assertLabel(React.findDOMNode(this), context, failureCB);
+        assertLabel(ReactDOM.findDOMNode(this), context, failureCB);
       });
 
       // Return true because the label check is now going to be async

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,7 @@ var logWarning = (component, failureInfo, options) => {
 
     if (includeSrcNode && component) {
       // TODO:
-      // 1) Consider using React.findDOMNode() over document.getElementById
+      // 1) Consider using ReactDOM.findDOMNode() over document.getElementById
       //    https://github.com/rackt/react-a11y/issues/54
       // 2) Consider using ref to expand element element reference logging
       //    to all element (https://github.com/rackt/react-a11y/issues/55)
@@ -164,18 +164,19 @@ var createId = function() {
   };
 }();
 
-var reactA11y = (React, options) => {
+var reactA11y = (React, options = {}) => {
+  const { ReactDOM } = options;
+
   if (!React && !React.createElement) {
     throw new Error('Missing parameter: React');
   }
 
-  assertions.setReact(React);
+  assertions.setReact(React, ReactDOM);
 
   _createElement = React.createElement;
 
   React.createElement = (type, _props, ...children) => {
     var props = _props || {};
-    options = options || {};
 
     var childrenForTest;
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "^2.0.1",
     "object.assign": "^4.0.3",
     "react": "^0.12 || ^0.13 || ^0.14",
+    "react-dom": "^0.14.7",
     "rf-release": "0.4.0",
     "webpack": "^1.4.13"
   },


### PR DESCRIPTION
Adds support for a `ReactDOM` key in the options hash, and uses that if provided, thereby maintaining 0.13 and 0.14 compatibility.

```js
import React from 'react';
import ReactDOM from 'react-dom';
import a11y from 'react-a11y';

a11y(React, { ReactDOM });
```

Fixes deprecation warnings from React.render and React.findDOMNode.

Future-proofs `react-a11y` for React 0.15

I'm hoping to have this merged because our build steps fails on any `console.warn`s, and I'd rather fix the issue than whitelist the `findDOMNode` warning