### PR TITLE
Remove babel-runtime

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,10 +25,18 @@ module.exports = function (config) {
       devtool: 'inline-source-map',
       module: {
         loaders: [
-          { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?optional=runtime' }
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loader: 'babel-loader',
+            query: {
+              plugins: ['transform-object-assign']
+            }
+          }
         ]
       },
       plugins: [
+        'transform-object-assign',
         new webpack.DefinePlugin({
           'process.env.NODE_ENV': JSON.stringify('test')
         })

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -21,7 +21,7 @@ var INTERACTIVE = {
   }
 };
 
-const presentationRoles = new Set(['presentation', 'none']);
+const presentationRoles = ['presentation', 'none'];
 
 var isHiddenFromAT = (props) => {
   return props['aria-hidden'] == 'true';
@@ -228,7 +228,7 @@ exports.render = {
   NO_LABEL: {
     msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
-      if (isHiddenFromAT(props) || presentationRoles.has(props.role))
+      if (isHiddenFromAT(props) || presentationRoles.indexOf(props.role) !== -1)
         return;
 
       if (!(

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,7 @@ var shouldRunTest = (testName, options) => {
   var exclude = options.exclude || [];
 
   if (options.device == 'mobile') {
-    exclude = new Set(exclude.concat(assertions.mobileExclusions));
-    exclude = [...exclude];
+    exclude = exclude.concat(assertions.mobileExclusions);
   }
 
   return (exclude.indexOf(testName) == -1);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "jsxhint . && karma start --single-run",
     "watch-tests": "npm test -- --watch",
-    "prepublish": "babel --optional runtime lib --out-dir dist",
+    "prepublish": "babel lib --out-dir dist",
     "release": "release"
   },
   "authors": [
@@ -25,7 +25,7 @@
     "babel": "^5.2.17",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
-    "babel-runtime": "^5.1.11",
+    "babel-plugin-transform-object-assign": "^6.5.0",
     "jsx-loader": "^0.12.2",
     "jsxhint": "^0.8.1",
     "karma": "^0.13.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 var webpack = require('webpack');
 
 var plugins = [
+  'transform-object-assign',
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production')
   })
@@ -35,7 +36,14 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?optional=runtime' }
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          plugins: ['transform-object-assign']
+        }
+      }
     ]
   }
 


### PR DESCRIPTION
Instead brings in "transform-object-assign" for Object.assign usage
and replaces Set usage with native Array