### PR TITLE
Remove babel-runtime

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
       devtool: 'inline-source-map',
       module: {
         loaders: [
-          { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?optional=runtime' }
+          { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
         ]
       },
       plugins: [

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -21,7 +21,7 @@ var INTERACTIVE = {
   }
 };
 
-const presentationRoles = new Set(['presentation', 'none']);
+const presentationRoles = ['presentation', 'none'];
 
 var isHiddenFromAT = (props) => {
   return props['aria-hidden'] == 'true';
@@ -228,7 +228,7 @@ exports.render = {
   NO_LABEL: {
     msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
-      if (isHiddenFromAT(props) || presentationRoles.has(props.role))
+      if (isHiddenFromAT(props) || presentationRoles.indexOf(props.role) !== -1)
         return;
 
       if (!(

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+var assign = require('object.assign');
 var assertions = require('./assertions');
 var after = require('./after');
 
@@ -5,8 +6,7 @@ var shouldRunTest = (testName, options) => {
   var exclude = options.exclude || [];
 
   if (options.device == 'mobile') {
-    exclude = new Set(exclude.concat(assertions.mobileExclusions));
-    exclude = [...exclude];
+    exclude = exclude.concat(assertions.mobileExclusions);
   }
 
   return (exclude.indexOf(testName) == -1);
@@ -185,7 +185,7 @@ var reactA11y = (React, options) => {
       childrenForTest = children;
     }
 
-    var newProps = Object.assign({}, props, {id: createId(props)});
+    var newProps = assign({}, props, {id: createId(props)});
     var reactEl = _createElement.apply(this, [type, newProps].concat(children));
     var failureCB = handleFailure.bind(undefined, options, reactEl);
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "jsxhint . && karma start --single-run",
     "watch-tests": "npm test -- --watch",
-    "prepublish": "babel --optional runtime lib --out-dir dist",
+    "prepublish": "babel lib --out-dir dist",
     "release": "release"
   },
   "authors": [
@@ -25,7 +25,6 @@
     "babel": "^5.2.17",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
-    "babel-runtime": "^5.1.11",
     "jsx-loader": "^0.12.2",
     "jsxhint": "^0.8.1",
     "karma": "^0.13.3",
@@ -36,6 +35,7 @@
     "karma-sourcemap-loader": "^0.3.2",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.0.1",
+    "object.assign": "^4.0.3",
     "react": "^0.12 || ^0.13 || ^0.14",
     "rf-release": "0.4.0",
     "webpack": "^1.4.13"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?optional=runtime' }
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
     ]
   }
 


### PR DESCRIPTION
Removes babel-runtime
Replaces Set usage with Array
Replaces Object.assign usage with object.assign module

I'm hoping to have this merged so that we don't need to include `babel-runtime` as a peer dependency, because we don't use `babel-runtime` and it could lead to a differences in test and production environments. 

Addresses https://github.com/reactjs/react-a11y/issues/76