### PR TITLE
Replace references to Rackt with ReactJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 React A11y
 ==========
 
-[![build status](https://img.shields.io/travis/rackt/react-a11y/master.svg?style=flat-square)](https://travis-ci.org/rackt/react-a11y)
+[![build status](https://img.shields.io/travis/reactjs/react-a11y/master.svg?style=flat-square)](https://travis-ci.org/reactjs/react-a11y)
 
 Warns about potential accessibility issues with your React elements.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,9 +102,9 @@ var logWarning = (component, failureInfo, options) => {
     if (includeSrcNode && component) {
       // TODO:
       // 1) Consider using ReactDOM.findDOMNode() over document.getElementById
-      //    https://github.com/rackt/react-a11y/issues/54
+      //    https://github.com/reactjs/react-a11y/issues/54
       // 2) Consider using ref to expand element element reference logging
-      //    to all element (https://github.com/rackt/react-a11y/issues/55)
+      //    to all element (https://github.com/reactjs/react-a11y/issues/55)
       let srcNode = document.getElementById(failureInfo.id);
 
       // Guard against logging null element references should render()

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rackt/react-a11y.git"
+    "url": "https://github.com/reactjs/react-a11y.git"
   },
-  "homepage": "https://github.com/rackt/react-a11y/blob/latest/README.md",
-  "bugs": "https://github.com/rackt/react-a11y/issues",
+  "homepage": "https://github.com/reactjs/react-a11y/blob/latest/README.md",
+  "bugs": "https://github.com/reactjs/react-a11y/issues",
   "scripts": {
     "test": "jsxhint . && karma start --single-run",
     "watch-tests": "npm test -- --watch",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ if (process.env.COMPRESS) {
 module.exports = {
 
   output: {
-    library: 'Rackt.A11y',
+    library: 'ReactJS.A11y',
     libraryTarget: 'var'
   },
 


### PR DESCRIPTION
This fixes the Travis build status badge and replaces all references to Rackt with ReactJS as per https://github.com/reactjs/react-a11y/issues/109