### PR TITLE
Fix for object.assign issue #115

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-var assign = require('object.assign');
 var assertions = require('./assertions');
 var after = require('./after');
 
@@ -186,7 +185,10 @@ var reactA11y = (React, options = {}) => {
       childrenForTest = children;
     }
 
-    var newProps = assign({}, props, {id: createId(props)});
+    var newProps = {
+      ...props,
+      id: createId(props)
+    };
     var reactEl = _createElement.apply(this, [type, newProps].concat(children));
     var failureCB = handleFailure.bind(undefined, options, reactEl);
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "karma-sourcemap-loader": "^0.3.2",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.0.1",
-    "object.assign": "^4.0.3",
     "react": "^0.12 || ^0.13 || ^0.14",
     "react-dom": "^0.14.7",
     "rf-release": "0.4.0",


### PR DESCRIPTION
### Problem ###
Currently there's an issue #115 open

### Fix ###
this fix doesn't require `object.assign` and uses spread operator intead to come up with new props.