### PR TITLE
[added] a11y.restoreAll() method to clean up mutations to React

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,14 @@ You can pass `ReactDOM` to `a11y` for `React 0.14` compatibility.
 ```
 a11y(React, { ReactDOM: ReactDOM });
 ```
+
+Cleaning Up In Tests
+--------------------
+
+Use the `restoreAll()` method to clean up mutations made to `React`.
+Useful if you are using React-a11y in your test suite.
+
+```js
+beforeEach(() => a11y(React));
+afterEach(() => a11y.restoreAll());
+```

--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -3,6 +3,7 @@ var ReactDOM = require('react-dom');
 var assert = require('assert');
 var a11y = require('../index');
 var assertions = require('../assertions');
+var _after = require('../after');
 
 var k = () => {};
 
@@ -27,15 +28,44 @@ var doNotExpectWarning = (notExpected, fn) => {
   assert(msgs[notExpected] == null, `Did not expect a warning but got "${notExpected}"`);
 };
 
-describe('props', () => {
-  var createElement = React.createElement;
+describe('a11y', () => {
+  describe('#restoreAll', () => {
+    let restorePatchedMethods;
+    let createElement;
 
+    beforeEach(() => {
+      restorePatchedMethods = _after.restorePatchedMethods;
+      createElement = React.createElement;
+    });
+
+    afterEach(() => {
+      _after.restorePatchedMethods = restorePatchedMethods;
+      React.createElement = createElement;
+    });
+
+    it('restores React.createElement', () => {
+      a11y(React);
+      assert(createElement !== React.createElement);
+      a11y.restoreAll();
+      assert(createElement === React.createElement);
+    });
+
+    it('calls after.restorePatchedMethods()', () => {
+      let called = false;
+      _after.restorePatchedMethods = () => called = true;
+      a11y.restoreAll();
+      assert(called);
+    });
+  });
+});
+
+describe('props', () => {
   before(() => {
     a11y(React, { ReactDOM });
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   describe('onClick', () => {
@@ -152,14 +182,12 @@ describe('props', () => {
 });
 
 describe('tags', () => {
-  var createElement = React.createElement;
-
   before(() => {
     a11y(React, { ReactDOM });
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   describe('img', () => {
@@ -232,7 +260,6 @@ describe('tags', () => {
 });
 
 describe('labels', () => {
-  var createElement = React.createElement;
   var fixture;
 
   before(() => {
@@ -240,7 +267,7 @@ describe('labels', () => {
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   beforeEach(() => {
@@ -567,7 +594,6 @@ describe('labels', () => {
 });
 
 describe('includeSrcNode is "asString"', () => {
-  var createElement = React.createElement;
   var fixture;
 
   before(() => {
@@ -578,7 +604,7 @@ describe('includeSrcNode is "asString"', () => {
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
     fixture = document.getElementById('fixture-1');
     if (fixture)
       document.body.removeChild(fixture);
@@ -606,8 +632,6 @@ describe('includeSrcNode is "asString"', () => {
 });
 
 describe('filterFn', () => {
-  var createElement = React.createElement;
-
   before(() => {
     var barOnly = (name, id, msg) => {
       return id === "bar";
@@ -617,7 +641,7 @@ describe('filterFn', () => {
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   describe('when the source element has been filtered out', () => {
@@ -641,14 +665,12 @@ describe('filterFn', () => {
 });
 
 describe('device is set to mobile', () => {
-  var createElement = React.createElement;
-
   before(() => {
     a11y(React, { device: ['mobile'] });
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   describe('when role="button"', () => {
@@ -667,14 +689,12 @@ describe('device is set to mobile', () => {
 });
 
 describe('exclusions', () => {
-  var createElement = React.createElement;
-
   before(() => {
     a11y(React, { exclude: ['REDUNDANT_ALT'] });
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   describe('when REDUNDANT_ALT is excluded', () => {
@@ -687,15 +707,13 @@ describe('exclusions', () => {
 });
 
 describe('warningPrefix', () => {
-  var createElement = React.createElement;
-
   let warningPrefix = 'react-a11y ERROR:';
   before(() => {
     a11y(React, { warningPrefix });
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   it('adds the prefix to each warning message', () => {
@@ -709,14 +727,12 @@ describe('warningPrefix', () => {
 });
 
 describe('testing children', () => {
-  var createElement = React.createElement;
-
   before(() => {
     a11y(React, { exclude: ['REDUNDANT_ALT'] });
   });
 
   after(() => {
-    React.createElement = createElement;
+    a11y.restoreAll();
   });
 
   describe('when children is passed down in props', () => {

--- a/lib/after.js
+++ b/lib/after.js
@@ -1,14 +1,28 @@
-var after = (host, name, cb) => {
-  var originalFn = host[name];
+let restoreFunctions = [];
+
+const after = (host, name, cb) => {
+  const originalFn = host[name];
+  let restoreFn;
 
   if (originalFn) {
     host[name] = function(...args) {
       originalFn.apply(this, args);
       cb.apply(this, args);
     };
+    restoreFn = () => host[name] = originalFn;
   } else {
-    host[name] = cb;
+    host[name] = function(...args) {
+      cb.apply(this, args);
+    };
+    restoreFn = () => delete host[name];
   }
+
+  restoreFunctions.push(restoreFn);
+};
+
+after.restorePatchedMethods = () => {
+  restoreFunctions.forEach(restoreFn => restoreFn());
+  restoreFunctions = [];
 };
 
 module.exports = after;

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,8 +164,11 @@ var createId = function() {
   };
 }();
 
-var reactA11y = (React, options = {}) => {
+let React;
+
+const reactA11y = (_React, options = {}) => {
   const { ReactDOM } = options;
+  React = _React;
 
   if (!React && !React.createElement) {
     throw new Error('Missing parameter: React');
@@ -195,6 +198,11 @@ var reactA11y = (React, options = {}) => {
 
     return reactEl;
   };
+};
+
+reactA11y.restoreAll = function() {
+  React.createElement = _createElement;
+  after.restorePatchedMethods();
 };
 
 module.exports = reactA11y;


### PR DESCRIPTION
`a11y` patches the `React.createElement` method, and sometimes
patches lifecycle events of components. This adds a `restoreAll`
method to `a11y` which cleans up after itself.

This is particularly useful for using `React-a11y` in JavaScript
test suites, where the patched `React` and/or components may be
reused in future tests.

cc @kloots who originally extracted `after`