### PR TITLE
Fix error when extending Array prototype

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,9 @@ var runTagTests = (tagName, props, children, options, onFailure) => {
   var tagTests = assertions.tags[tagName] || [];
 
   for (key in tagTests) {
+    if (!tagTests.hasOwnProperty(key)) {
+      continue;
+    }
     let testFailed = shouldRunTest(key, options) &&
       !tagTests[key].test(tagName, props, children);
 
@@ -35,6 +38,9 @@ var runPropTests = (tagName, props, children, options, onFailure) => {
     propTests = assertions.props[propName] || [];
 
     for (key in propTests) {
+      if (!propTests.hasOwnProperty(key)) {
+        continue;
+      }
       let testTailed = shouldRunTest(key, options) &&
         !propTests[key].test(tagName, props, children);
 


### PR DESCRIPTION
When extending `Array` prototype, the whole app was broken if using `react-a11y`. This is an attempt at fixing it, which does the work for me.

Not sure it is the best way to solve it, nor it covers everything. Sorry if this is not the case.
