### PR TITLE
[doc] always include ReactDOM as option for React >= 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ a11y(React, { exclude: ['REDUNDANT_ALT'] });
 ReactDOM
 --------
 
-You can pass `ReactDOM` to `a11y` for `React 0.14` compatibility.
+You should pass `ReactDOM` to `a11y` for `React >= 0.14` compatibility.
 
 ```
 a11y(React, { ReactDOM: ReactDOM });


### PR DESCRIPTION
Small documentation improvement to reflect it should always be passed. Any use of `ReactDOM.findDOMNode` for example will result in errors when `ReactDOM` is not passed as `setReact` is defaulting to `React` which no longer has that function.