### PR TITLE
Don't throw violations for valid inputs with type="submit"

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -402,6 +402,18 @@ describe('labels', () => {
       <input type="text"/>;
     });
   });
+  
+  it('does not warn for submit inputs with a value', () => {
+    doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+      <input type="submit" value="the name" />;
+    });
+  });
+
+  it('warns for submit inputs without a value', () => {
+    expectWarning(assertions.render.NO_LABEL.msg, () => {
+      <input type="submit" />;
+    });
+  });
 
   it('warns if an anchor has a tabIndex but no href', () => {
     expectWarning(assertions.render.NO_LABEL.msg, () => {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -230,6 +230,7 @@ exports.render = {
   NO_LABEL: {
     msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
+      var isValidSubmit = tagName === "input" && props.type === "submit" && props.value != null;
       if (isHiddenFromAT(props) || presentationRoles.indexOf(props.role) !== -1)
         return;
 
@@ -244,6 +245,7 @@ exports.render = {
       var failed = !(
         props['aria-label'] ||
         props['aria-labelledby'] ||
+        isValidSubmit ||
         (tagName === 'img' && props.alt) ||
         hasChildTextNode(props, children, failureCB)
       );


### PR DESCRIPTION
## What is this?

We were getting false fails for "unlabeled inputs" that have `type="submit"` and a `value` attribute. These are valid inputs. This PR changes it so it will only throw a violation for inputs that have `type="submit"` but no `value` attribute. 