### PR TITLE
WIP: Don't throw warnings for inputs with type="button"

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -414,6 +414,18 @@ describe('labels', () => {
       <input type="submit" />;
     });
   });
+  
+  it('does not warn for button inputs with a value', () => {
+    doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+      <input type="button" value="the name" />;
+    });
+  });
+
+  it('warns for button inputs without a value', () => {
+    expectWarning(assertions.render.NO_LABEL.msg, () => {
+      <input type="button" />;
+    });
+  });
 
   it('warns if an anchor has a tabIndex but no href', () => {
     expectWarning(assertions.render.NO_LABEL.msg, () => {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -230,7 +230,9 @@ exports.render = {
   NO_LABEL: {
     msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
-      var isValidSubmit = tagName === "input" && props.type === "submit" && props.value != null;
+      var isValidInputType = props.type === "submit" || props.type === "button";
+      var isValidInput = tagName === "input" && isValidInputType && props.value != null;
+      
       if (isHiddenFromAT(props) || presentationRoles.indexOf(props.role) !== -1)
         return;
 
@@ -245,7 +247,7 @@ exports.render = {
       var failed = !(
         props['aria-label'] ||
         props['aria-labelledby'] ||
-        isValidSubmit ||
+        isValidInput ||
         (tagName === 'img' && props.alt) ||
         hasChildTextNode(props, children, failureCB)
       );

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -231,7 +231,7 @@ exports.render = {
     msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
       var isValidInputType = props.type === "submit" || props.type === "button";
-      var isValidInput = tagName === "input" && isValidInputType && props.value != null;
+      var isValidInputButton = tagName === "input" && isValidInputType && props.value != null;
       
       if (isHiddenFromAT(props) || presentationRoles.indexOf(props.role) !== -1)
         return;
@@ -247,7 +247,7 @@ exports.render = {
       var failed = !(
         props['aria-label'] ||
         props['aria-labelledby'] ||
-        isValidInput ||
+        isValidInputButton ||
         (tagName === 'img' && props.alt) ||
         hasChildTextNode(props, children, failureCB)
       );


### PR DESCRIPTION
I'm marking this a WIP because I can't remove that merge commit until I get home. I can't push to GitHub from my work computer so the only way for me to get the last updates was to merge. I'll clean that up.

## What is this?

As I add this package to our project I noticed I was getting warnings for inputs that are `type="button"`. This should clean up those warnings. 