### PR TITLE
[fixed] Resolving issue #137 where getName() in React 16 is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -131,11 +131,17 @@ var handleFailure = (options, reactEl, type, props, failureMsg) => {
   var includeSrcNode = options && (options.includeSrcNode || false);
   var warningPrefix = (options && options.warningPrefix) || '';
   var reactComponent = reactEl._owner;
+  
+  // Validate component name against React Version
+  // Version <= 15 use reactComponent.getName()
+  // Version >= 16 use reactComponent.type.name
+  var reactComponentName = Boolean(reactComponent.type)
+    ? reactComponent.type.name
+    : reactComponent.getName();
 
   // If a Component instance, use the component's name,
   // if a ReactElement instance, use the tag name + id (e.g. div#foo)
-  var name = reactComponent && reactComponent.getName() ||
-    type + '#' + props.id;
+  var name = reactComponent && reactComponentName || type + '#' + props.id;
 
   var failureInfo = {
     'tagName': name ,

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,9 +135,7 @@ var handleFailure = (options, reactEl, type, props, failureMsg) => {
   // Validate component name against React Version
   // Version <= 15 use reactComponent.getName()
   // Version >= 16 use reactComponent.type.name
-  var reactComponentName = Boolean(reactComponent.type)
-    ? reactComponent.type.name
-    : reactComponent.getName();
+  var reactComponentName = Boolean(reactComponent.type) ? reactComponent.type.name : reactComponent.getName();
 
   // If a Component instance, use the component's name,
   // if a ReactElement instance, use the tag name + id (e.g. div#foo)


### PR DESCRIPTION
Resolving minor syntax issues with previous pull request. The previous pull request aimed to resolve the issue where reactComponent.getName() is returning undefined.