### PR TITLE
onclick-uses-role shouldn't fire for negative tabIndex

### DIFF
--- a/src/rules/onclick-uses-role.js
+++ b/src/rules/onclick-uses-role.js
@@ -15,11 +15,12 @@ export default [{
     ],
     test(tagName, props) {
         const hidden = hiddenFromAT(props);
+        const negativeTabIndex = props["tabIndex"] == -1;
         const interactive = isInteractive(tagName, props);
         const onClick = listensTo(props, 'onClick');
         const role = 'role' in props;
 
-        return hidden || interactive || !onClick || role;
+        return hidden || interactive || !onClick || role || negativeTabIndex;
     }
 }];
 
@@ -39,6 +40,9 @@ export const pass = [{
 }, {
     when: 'the element is interactive',
     render: React => <button onClick={fn} />
+}, {
+    when: "the element have negative tabIndex",
+    render: React => <span onClick={fn} tabIndex="-1" />
 }];
 
 export const description = `


### PR DESCRIPTION
I think adding `tabIndex="-1"` to elements with onClick handler is valid usecase and this plugin shouldn't force `role` attributes on those.  (as they cant be focusable anyway)

My usecase is: We have onClick on parent element that is just overlay of modal, but closes modal when its clicked. I don't want to add role to it, or make it focusable as modal can be closed with close button as well or with Escape key. 
