### PR TITLE
Remove babel-register from dependencies as this pulls in babel-core 6…

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "a11y"
   ],
   "dependencies": {
-    "babel-register": "^6.26.0"
   },
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
… which means that babel 7 can't be used cleanly.
