### PR TITLE
New rule: Link is readable

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,34 +1,35 @@
 /* eslint-disable global-require */
 export default {
-  'click-events-have-key-events': require('./click-events-have-key-events')
-    .default,
-  'hidden-uses-tabindex': require('./hidden-uses-tabindex').default,
-  'img-uses-alt': require('./img-uses-alt').default,
-  'label-has-for': require('./label-has-for').default,
-  'mouse-events-have-key-events': require('./mouse-events-have-key-events')
-    .default,
-  'onclick-uses-role': require('./onclick-uses-role').default,
-  'interactive-supports-focus': require('./interactive-supports-focus').default,
-  'no-access-key': require('./no-access-key').default,
-  'no-hash-ref': require('./no-hash-ref').default,
-  'img-redundant-alt': require('./img-redundant-alt').default,
-  'no-onchange': require('./no-onchange').default,
-  'aria-role': require('./aria-role').default,
-  'tabindex-no-positive': require('./tabindex-no-positive').default,
-  'tabindex-uses-button': require('./tabindex-uses-button').default,
-  'aria-unsupported-elements': require('./aria-unsupported-elements').default,
-  'link-is-readable': require('./link-is-readable').default,
+    'click-events-have-key-events': require('./click-events-have-key-events')
+        .default,
+    'hidden-uses-tabindex': require('./hidden-uses-tabindex').default,
+    'img-uses-alt': require('./img-uses-alt').default,
+    'label-has-for': require('./label-has-for').default,
+    'mouse-events-have-key-events': require('./mouse-events-have-key-events')
+        .default,
+    'onclick-uses-role': require('./onclick-uses-role').default,
+    'interactive-supports-focus': require('./interactive-supports-focus')
+        .default,
+    'no-access-key': require('./no-access-key').default,
+    'no-hash-ref': require('./no-hash-ref').default,
+    'img-redundant-alt': require('./img-redundant-alt').default,
+    'no-onchange': require('./no-onchange').default,
+    'aria-role': require('./aria-role').default,
+    'tabindex-no-positive': require('./tabindex-no-positive').default,
+    'tabindex-uses-button': require('./tabindex-uses-button').default,
+    'aria-unsupported-elements': require('./aria-unsupported-elements').default,
+    'link-is-readable': require('./link-is-readable').default,
 
-  // DEPRECATED RULES
-  'avoid-positive-index': require('./avoid-positive-index').default,
-  'button-role-space': require('./button-role-space').default,
-  'label-uses-for': require('./label-uses-for').default,
-  'mouse-events-map-to-key-events': require('./mouse-events-map-to-key-events')
-    .default,
-  'onclick-uses-tabindex': require('./onclick-uses-tabindex').default,
-  'redundant-alt': require('./redundant-alt').default,
-  'use-onblur-not-onchange': require('./use-onblur-not-onchange').default,
-  'valid-aria-role': require('./valid-aria-role').default,
-  'no-unsupported-elements-use-aria': require('./no-unsupported-elements-use-aria')
-    .default
-}
+    // DEPRECATED RULES
+    'avoid-positive-index': require('./avoid-positive-index').default,
+    'button-role-space': require('./button-role-space').default,
+    'label-uses-for': require('./label-uses-for').default,
+    'mouse-events-map-to-key-events': require('./mouse-events-map-to-key-events')
+        .default,
+    'onclick-uses-tabindex': require('./onclick-uses-tabindex').default,
+    'redundant-alt': require('./redundant-alt').default,
+    'use-onblur-not-onchange': require('./use-onblur-not-onchange').default,
+    'valid-aria-role': require('./valid-aria-role').default,
+    'no-unsupported-elements-use-aria': require('./no-unsupported-elements-use-aria')
+        .default
+};

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,15 +1,12 @@
 /* eslint-disable global-require */
 export default {
-    'click-events-have-key-events': require('./click-events-have-key-events')
-        .default,
+    'click-events-have-key-events': require('./click-events-have-key-events').default,
     'hidden-uses-tabindex': require('./hidden-uses-tabindex').default,
     'img-uses-alt': require('./img-uses-alt').default,
     'label-has-for': require('./label-has-for').default,
-    'mouse-events-have-key-events': require('./mouse-events-have-key-events')
-        .default,
+    'mouse-events-have-key-events': require('./mouse-events-have-key-events').default,
     'onclick-uses-role': require('./onclick-uses-role').default,
-    'interactive-supports-focus': require('./interactive-supports-focus')
-        .default,
+    'interactive-supports-focus': require('./interactive-supports-focus').default,
     'no-access-key': require('./no-access-key').default,
     'no-hash-ref': require('./no-hash-ref').default,
     'img-redundant-alt': require('./img-redundant-alt').default,
@@ -24,12 +21,10 @@ export default {
     'avoid-positive-index': require('./avoid-positive-index').default,
     'button-role-space': require('./button-role-space').default,
     'label-uses-for': require('./label-uses-for').default,
-    'mouse-events-map-to-key-events': require('./mouse-events-map-to-key-events')
-        .default,
+    'mouse-events-map-to-key-events': require('./mouse-events-map-to-key-events').default,
     'onclick-uses-tabindex': require('./onclick-uses-tabindex').default,
     'redundant-alt': require('./redundant-alt').default,
     'use-onblur-not-onchange': require('./use-onblur-not-onchange').default,
     'valid-aria-role': require('./valid-aria-role').default,
-    'no-unsupported-elements-use-aria': require('./no-unsupported-elements-use-aria')
-        .default
+    'no-unsupported-elements-use-aria': require('./no-unsupported-elements-use-aria').default
 };

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,29 +1,34 @@
 /* eslint-disable global-require */
 export default {
-    'click-events-have-key-events': require('./click-events-have-key-events').default,
-    'hidden-uses-tabindex': require('./hidden-uses-tabindex').default,
-    'img-uses-alt': require('./img-uses-alt').default,
-    'label-has-for': require('./label-has-for').default,
-    'mouse-events-have-key-events': require('./mouse-events-have-key-events').default,
-    'onclick-uses-role': require('./onclick-uses-role').default,
-    'interactive-supports-focus': require('./interactive-supports-focus').default,
-    'no-access-key': require('./no-access-key').default,
-    'no-hash-ref': require('./no-hash-ref').default,
-    'img-redundant-alt': require('./img-redundant-alt').default,
-    'no-onchange': require('./no-onchange').default,
-    'aria-role': require('./aria-role').default,
-    'tabindex-no-positive': require('./tabindex-no-positive').default,
-    'tabindex-uses-button': require('./tabindex-uses-button').default,
-    'aria-unsupported-elements': require('./aria-unsupported-elements').default,
+  'click-events-have-key-events': require('./click-events-have-key-events')
+    .default,
+  'hidden-uses-tabindex': require('./hidden-uses-tabindex').default,
+  'img-uses-alt': require('./img-uses-alt').default,
+  'label-has-for': require('./label-has-for').default,
+  'mouse-events-have-key-events': require('./mouse-events-have-key-events')
+    .default,
+  'onclick-uses-role': require('./onclick-uses-role').default,
+  'interactive-supports-focus': require('./interactive-supports-focus').default,
+  'no-access-key': require('./no-access-key').default,
+  'no-hash-ref': require('./no-hash-ref').default,
+  'img-redundant-alt': require('./img-redundant-alt').default,
+  'no-onchange': require('./no-onchange').default,
+  'aria-role': require('./aria-role').default,
+  'tabindex-no-positive': require('./tabindex-no-positive').default,
+  'tabindex-uses-button': require('./tabindex-uses-button').default,
+  'aria-unsupported-elements': require('./aria-unsupported-elements').default,
+  'link-is-readable': require('./link-is-readable').default,
 
-    // DEPRECATED RULES
-    'avoid-positive-index': require('./avoid-positive-index').default,
-    'button-role-space': require('./button-role-space').default,
-    'label-uses-for': require('./label-uses-for').default,
-    'mouse-events-map-to-key-events': require('./mouse-events-map-to-key-events').default,
-    'onclick-uses-tabindex': require('./onclick-uses-tabindex').default,
-    'redundant-alt': require('./redundant-alt').default,
-    'use-onblur-not-onchange': require('./use-onblur-not-onchange').default,
-    'valid-aria-role': require('./valid-aria-role').default,
-    'no-unsupported-elements-use-aria': require('./no-unsupported-elements-use-aria').default
-};
+  // DEPRECATED RULES
+  'avoid-positive-index': require('./avoid-positive-index').default,
+  'button-role-space': require('./button-role-space').default,
+  'label-uses-for': require('./label-uses-for').default,
+  'mouse-events-map-to-key-events': require('./mouse-events-map-to-key-events')
+    .default,
+  'onclick-uses-tabindex': require('./onclick-uses-tabindex').default,
+  'redundant-alt': require('./redundant-alt').default,
+  'use-onblur-not-onchange': require('./use-onblur-not-onchange').default,
+  'valid-aria-role': require('./valid-aria-role').default,
+  'no-unsupported-elements-use-aria': require('./no-unsupported-elements-use-aria')
+    .default
+}

--- a/src/rules/link-is-readable.js
+++ b/src/rules/link-is-readable.js
@@ -3,10 +3,12 @@ import { hasProp, isReadable } from '../util';
 export default [
     {
         tagName: 'a',
-        msg: 'Links should be readable.',
+        msg:
+            'Links should contain text, images with alt attributes, or have an ' +
+            "aria-label attribute so that users understand the link's purpose.",
         url:
             'https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html',
-        //AX: 'AX_ARIA_01', <- gotta look this up
+        AX: 'AX_TEXT_04',
         test(tagName, props, children, ctx) {
             const text = [];
 
@@ -53,6 +55,15 @@ export const fail = [
         when: 'a link is just a non-breaking space',
         // eslint-disable-next-line jsx-a11y/link-is-readable
         render: React => <a href="/home">&nbsp;</a>
+    },
+    {
+        when: 'a link has an image with empty alt',
+        // eslint-disable-next-line jsx-a11y/link-is-readable
+        render: React => (
+            <a href="/home">
+                <img src="home.png" alt="" />
+            </a>
+        )
     },
     {
         when: 'a link has an image with empty alt',

--- a/src/rules/link-is-readable.js
+++ b/src/rules/link-is-readable.js
@@ -1,0 +1,106 @@
+import { hasProp, isReadable } from '../util';
+
+export default [
+    {
+        tagName: 'a',
+        msg: 'Links should be readable.',
+        url:
+            'https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html',
+        //AX: 'AX_ARIA_01', <- gotta look this up
+        test(tagName, props, children, ctx) {
+            const text = [];
+
+            if (hasProp(props, 'aria-label')) {
+                text.push(props['aria-label']);
+            }
+
+            const collectTextFromChildren = children => {
+                if (typeof children === 'string') {
+                    text.push(children);
+                    return;
+                }
+                children.forEach(child => {
+                    if (typeof child === 'string') {
+                        text.push(child);
+                        return;
+                    }
+                    if (child.type === 'img' && hasProp(child.props, 'alt')) {
+                        text.push(child.props.alt);
+                    }
+                    if (
+                        child.props &&
+                        typeof child.props.children !== 'undefined'
+                    ) {
+                        collectTextFromChildren(child.props.children);
+                    }
+                });
+            };
+
+            collectTextFromChildren(children);
+
+            return isReadable(text.join(''));
+        }
+    }
+];
+
+export const fail = [
+    {
+        when: 'a link is empty',
+        // eslint-disable-next-line jsx-a11y/link-is-readable
+        render: React => <a href="/home" />
+    },
+    {
+        when: 'a link has an image with empty alt',
+        // eslint-disable-next-line jsx-a11y/link-is-readable
+        render: React => (
+            <a href="/home">
+                <img src="home.png" alt="" />
+            </a>
+        )
+    }
+];
+
+export const pass = [
+    {
+        when: 'The link has text',
+        render: React => <a href="/home">Homepage</a>
+    },
+    {
+        when: 'The link has text in a descendent',
+        render: React => (
+            <a href="/home">
+                <span>Homepage</span>
+            </a>
+        )
+    },
+    {
+        when: 'Link has aria-label',
+        render: React => <a href="/home" aria-label="Homepage" />
+    },
+    {
+        when: 'a link has an image with an alt attribute',
+        // eslint-disable-next-line jsx-a11y/link-is-readable
+        render: React => (
+            <a href="/home">
+                <img src="home.png" alt="Homepage" />
+            </a>
+        )
+    },
+    {
+        when:
+            'a link has an image with an empty alt attribute and there is text',
+        // eslint-disable-next-line jsx-a11y/link-is-readable
+        render: React => (
+            <a href="/home">
+                <img src="home.png" alt="" />
+                Homepage
+            </a>
+        )
+    }
+];
+
+export const description = `
+Links should be readable and describe the destination 
+or action associated with it. When using images within 
+links, the alternate text in the image is read.
+`;

--- a/src/rules/link-is-readable.js
+++ b/src/rules/link-is-readable.js
@@ -9,7 +9,7 @@ export default [
         url:
             'https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html',
         AX: 'AX_TEXT_04',
-        test(tagName, props, children, ctx) {
+        test(tagName, props, children) {
             const text = [];
 
             if (hasProp(props, 'aria-label')) {

--- a/src/rules/link-is-readable.js
+++ b/src/rules/link-is-readable.js
@@ -50,6 +50,11 @@ export const fail = [
         render: React => <a href="/home" />
     },
     {
+        when: 'a link is just a non-breaking space',
+        // eslint-disable-next-line jsx-a11y/link-is-readable
+        render: React => <a href="/home">&nbsp;</a>
+    },
+    {
         when: 'a link has an image with empty alt',
         // eslint-disable-next-line jsx-a11y/link-is-readable
         render: React => (

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -19,10 +19,7 @@ export const devices = {
 export const fn = () => null;
 
 // builds url for specific google AX Rule
-export const AXURL = ax =>
-    `https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#${ax}`;
+export const AXURL = ax => `https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#${ax}`;
 
 export const warnRuleDeprecated = (currentRule, newRule) =>
-    console.warn(
-        `[react-a11y]: Warning: the rule ${currentRule} is deprecated.  Use the rule ${newRule} instead.`
-    );
+    console.warn(`[react-a11y]: Warning: the rule ${currentRule} is deprecated.  Use the rule ${newRule} instead.`);

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,5 +1,6 @@
 export { default as isInteractive } from './is-interactive';
 export { default as hiddenFromAT } from './hidden-from-at';
+export { default as isReadable } from './is-readable';
 export { default as listensTo } from './listens-to';
 export { default as trueish } from './trueish';
 export { default as hasProp } from './has-prop';
@@ -18,7 +19,10 @@ export const devices = {
 export const fn = () => null;
 
 // builds url for specific google AX Rule
-export const AXURL = ax => `https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#${ax}`;
+export const AXURL = ax =>
+    `https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#${ax}`;
 
 export const warnRuleDeprecated = (currentRule, newRule) =>
-    console.warn(`[react-a11y]: Warning: the rule ${currentRule} is deprecated.  Use the rule ${newRule} instead.`);
+    console.warn(
+        `[react-a11y]: Warning: the rule ${currentRule} is deprecated.  Use the rule ${newRule} instead.`
+    );

--- a/src/util/is-readable.js
+++ b/src/util/is-readable.js
@@ -1,0 +1,5 @@
+const isReadable = text => {
+  return text.replace(/\s/g, '').length > 1;
+};
+
+export default isReadable;


### PR DESCRIPTION
Mostly for [WCAG SC 2.4.4](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html), this rule checks all links for the presence of:

- Readable (definition below) text nodes
- Images with alternate text
- An `aria-label` attribute

This PR also includes a isReadable utility, which is pretty simple right now, but could be helpful for future rules that check to see if text is actually going to be usable by a screen reader.