### PR TITLE
doc: upgrade to new rule in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ if (process.env.NODE_ENV === 'development') {
   a11y(React, ReactDOM, {
     rules: {
       'img-uses-alt': 'warn',
-      'redundant-alt': [ 'warn', [ 'image', 'photo', 'foto', 'bild' ]]
+      'img-redundant-alt': [ 'warn', [ 'image', 'photo', 'foto', 'bild' ]]
     // ...
     }
   });


### PR DESCRIPTION
Thanks for the awesome package!
After I add the package, and add demo codes, I got the warning immediately. I thought I did something wrong.

> [react-a11y]: Warning: the rule redundant-alt is deprecated.  Use the rule img-redundant-alt instead.
 
Then I found I need upgrade the codes based on the migration. I feel it might provide a better experience to just let user use new rule directly : ) 
