### PR TITLE
Updated deprication warning to use link to new repo for @axe-core/react

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Identifies accessibility issues in your React.js elements
 
 
 # ⛔️DEPRECATION NOTICE ⛔️
-This library is being deprecated in favor of [react-axe](https://github.com/dequelabs/react-axe).  
+This library is being deprecated in favor of [@axe-core/react](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react).  
 Deque Systems are one of the top authorities on web accessibility.  Their auditing tools based on their axe-core 
 engine are unrivaled and have become the gold standard for auditing web accessibility issues.  Now that they have 
 developed a runtime React DOM auditing tool, that does what react-a11y attempts to do but better, it seems 
 counterproductive to continue to maintain react-a11y.  Let's pool our resources and energies into the best product and 
 I believe any accessibility tool backed by the experts at Deque Systems is bound to be one we can trust and depend on. 
-Please go check out and install [react-axe](https://github.com/dequelabs/react-axe) today!
+Please go check out and install [@axe-core/react](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react) today!
 
 ## Installation
 


### PR DESCRIPTION
Fixes #177 

[react-axe](https://github.com/dequelabs/react-axe) has been deprecated in a move to [@axe-core/react](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react). I discovered this when I visited the current link and then had to follow the second deprecation link on react-axe. I updated the package name and link in this readme so future engineers would be saved a step.